### PR TITLE
chartObject.clearChart() throws exception for Map charts because map doesn't have that function

### DIFF
--- a/src/components/GChart.vue
+++ b/src/components/GChart.vue
@@ -79,7 +79,7 @@ export default {
   },
 
   beforeDestroy () {
-    if (this.chartObject) {
+    if (this.chartObject && typeof this.chartObject.clearChart === 'function') {
       this.chartObject.clearChart()
     }
   },


### PR DESCRIPTION
According to the docs for the [Map chart type](https://developers.google.com/chart/interactive/docs/gallery/map#methods), the clearChart() function does not exist, so the fix proposed in #25 causes this exception:
~~~
[Vue warn]: Error in beforeDestroy hook: "TypeError: this.chartObject.clearChart is not a function"

found in

---> <GChart>
~~~