### PR TITLE
Move destroy behaviour from before to after

### DIFF
--- a/src/components/GChart.vue
+++ b/src/components/GChart.vue
@@ -78,7 +78,7 @@ export default {
     if (this.resizeDebounce > 0) window.addEventListener('resize', debounce(this.drawChart, this.resizeDebounce))
   },
 
-  beforeDestroy () {
+  afterDestroy () {
     if (this.chartObject && typeof this.chartObject.clearChart === 'function') {
       this.chartObject.clearChart()
     }


### PR DESCRIPTION

https://user-images.githubusercontent.com/2356771/107051920-1654f800-67de-11eb-8b7e-fc10229712ba.mov

In this case google-chart present in a Nuxt page, which uses transition around a router, thereafore chart dissapres on page change, I've replaced `beforeDestroy` to `afterDestroy` callback to fix the issue